### PR TITLE
Fix for compilation errors

### DIFF
--- a/catena4410_sensor1/catena4410_sensor1.ino
+++ b/catena4410_sensor1/catena4410_sensor1.ino
@@ -400,8 +400,7 @@ void startSendingUplink(void)
   gLoRaWAN.SendBuffer(b.getbase(), b.getn(), sendBufferDoneCb, NULL);
 }
 
-static void
-sendBufferDoneCb(
+static void sendBufferDoneCb(
     void *pContext,
     bool fStatus
     )

--- a/catena4420_test01/catena4420_test01.ino
+++ b/catena4420_test01/catena4420_test01.ino
@@ -256,8 +256,7 @@ void startSendingUplink(void)
   gLoRaWAN.SendBuffer(b.getbase(), b.getn(), sendBufferDoneCb, NULL);
 }
 
-static void
-sendBufferDoneCb(
+static void sendBufferDoneCb(
     void *pContext,
     bool fStatus
     )

--- a/catena4450m101_sensor/catena4450m101_sensor.ino
+++ b/catena4450m101_sensor/catena4450m101_sensor.ino
@@ -572,8 +572,7 @@ void startSendingUplink(void)
         gLoRaWAN.SendBuffer(b.getbase(), b.getn(), sendBufferDoneCb, NULL, fConfirmed);
         }
 
-static void
-sendBufferDoneCb(
+static void sendBufferDoneCb(
         void *pContext,
         bool fStatus
         )
@@ -597,8 +596,7 @@ sendBufferDoneCb(
                 );
         }
 
-static void
-txFailedDoneCb(
+static void txFailedDoneCb(
         osjob_t *pSendJob
         )
         {

--- a/catena4450m102_pond/catena4450m102_pond.ino
+++ b/catena4450m102_pond/catena4450m102_pond.ino
@@ -602,8 +602,7 @@ void startSendingUplink(void)
         gLoRaWAN.SendBuffer(b.getbase(), b.getn(), sendBufferDoneCb, NULL, fConfirmed);
         }
 
-static void
-sendBufferDoneCb(
+static void sendBufferDoneCb(
         void *pContext,
         bool fStatus
         )
@@ -627,8 +626,7 @@ sendBufferDoneCb(
                 );
         }
 
-static void
-txFailedDoneCb(
+static void txFailedDoneCb(
         osjob_t *pSendJob
         )
         {

--- a/catena4450m102_waterlevel/catena4450m102_waterlevel.ino
+++ b/catena4450m102_waterlevel/catena4450m102_waterlevel.ino
@@ -564,8 +564,7 @@ void startSendingUplink(void)
   gLoRaWAN.SendBuffer(b.getbase(), b.getn(), sendBufferDoneCb, NULL);
 }
 
-static void
-sendBufferDoneCb(
+static void sendBufferDoneCb(
     void *pContext,
     bool fStatus
     )
@@ -589,8 +588,7 @@ sendBufferDoneCb(
             );
     }
 
-static void
-txFailedDoneCb(
+static void txFailedDoneCb(
         osjob_t *pSendJob
         )
         {

--- a/catena4460_aqi/catena4460_aqi.ino
+++ b/catena4460_aqi/catena4460_aqi.ino
@@ -413,8 +413,7 @@ void startSendingUplink(void)
   gLoRaWAN.SendBuffer(b.getbase(), b.getn(), sendBufferDoneCb, NULL);
 }
 
-static void
-sendBufferDoneCb(
+static void sendBufferDoneCb(
     void *pContext,
     bool fStatus
     )
@@ -438,8 +437,7 @@ sendBufferDoneCb(
             );
     }
 
-static void
-txFailedDoneCb(
+static void txFailedDoneCb(
         osjob_t *pSendJob
         )
         {

--- a/catena4460_bsec_ulp/catena4460_bsec_ulp.ino
+++ b/catena4460_bsec_ulp/catena4460_bsec_ulp.ino
@@ -670,8 +670,7 @@ void startSendingUplink(void)
         gLoRaWAN.SendBuffer(b.getbase(), b.getn(), sendBufferDoneCb, nullptr, fConfirmed);
         }
 
-static void
-sendBufferDoneCb(
+static void sendBufferDoneCb(
         void *pContext,
         bool fStatus
         )
@@ -695,8 +694,7 @@ sendBufferDoneCb(
                 );
         }
 
-static void
-txFailedDoneCb(
+static void txFailedDoneCb(
         osjob_t *pSendJob
         )
         {

--- a/catena4551_test01/catena4551_test01.ino
+++ b/catena4551_test01/catena4551_test01.ino
@@ -658,8 +658,7 @@ void startSendingUplink(void)
 	gLoRaWAN.SendBuffer(b.getbase(), b.getn(), sendBufferDoneCb, NULL);
 	}
 
-static void
-sendBufferDoneCb(
+static void sendBufferDoneCb(
 	void *pContext,
 	bool fStatus
 	)
@@ -683,8 +682,7 @@ sendBufferDoneCb(
 		);
 	}
 
-static void
-txFailedDoneCb(
+static void txFailedDoneCb(
 	osjob_t *pSendJob
 	)
 	{

--- a/catena461x_test01/catena461x_test01.ino
+++ b/catena461x_test01/catena461x_test01.ino
@@ -645,8 +645,7 @@ void startSendingUplink(void)
 	gLoRaWAN.SendBuffer(b.getbase(), b.getn(), sendBufferDoneCb, NULL);
 	}
 
-static void
-sendBufferDoneCb(
+static void sendBufferDoneCb(
 	void *pContext,
 	bool fStatus
 	)
@@ -670,8 +669,7 @@ sendBufferDoneCb(
 		);
 	}
 
-static void
-txFailedDoneCb(
+static void txFailedDoneCb(
 	osjob_t *pSendJob
 	)
 	{


### PR DESCRIPTION
If a function definition has the type on a separate line it generates
compilation errors.  The solution is to move them to the same line.