### PR TITLE
Fix #70: don't shut down TX loop unless not provisioned

### DIFF
--- a/catena4612_simple/catena4612_simple.ino
+++ b/catena4612_simple/catena4612_simple.ino
@@ -3,22 +3,22 @@
 Module:  catena4612_simple.ino
 
 Function:
-	Test program for Catena 4612 and variants.
+        Test program for Catena 4612 and variants.
 
 Copyright notice:
-	This file copyright (C) 2019 by
+        This file copyright (C) 2019 by
 
-		MCCI Corporation
-		3520 Krums Corners Road
-		Ithaca, NY  14850
+                MCCI Corporation
+                3520 Krums Corners Road
+                Ithaca, NY  14850
 
-	See project LICENSE file for license information.
+        See project LICENSE file for license information.
 
 Author:
-	Terry Moore, MCCI Corporation	February 2019
+        Terry Moore, MCCI Corporation	February 2019
 
 Revision history:
-	See https://github.com/mcci-catena/Catena-Sketches
+        See https://github.com/mcci-catena/Catena-Sketches
 
 */
 
@@ -41,7 +41,7 @@ Revision history:
 #include <type_traits>
 
 using namespace McciCatena;
-
+
 /****************************************************************************\
 |
 |	MANIFEST CONSTANTS & TYPEDEFS
@@ -151,10 +151,10 @@ Catena_Si1133 gSi1133;
 bool fLight;
 
 SPIClass gSPI2(
-		Catena::PIN_SPI2_MOSI,
-		Catena::PIN_SPI2_MISO,
-		Catena::PIN_SPI2_SCK
-		);
+                Catena::PIN_SPI2_MOSI,
+                Catena::PIN_SPI2_MISO,
+                Catena::PIN_SPI2_SCK
+                );
 
 //   The flash
 Catena_Mx25v8035f gFlash;
@@ -176,41 +176,41 @@ unsigned gTxCycle;
 unsigned gTxCycleCount;
 
 
-
+
 /*
 
 Name:	setup()
 
 Function:
-	Arduino setup function.
+        Arduino setup function.
 
 Definition:
-	void setup(
-	    void
-	    );
+        void setup(
+            void
+            );
 
 Description:
-	This function is called by the Arduino framework after
-	basic framework has been initialized. We initialize the sensors
-	that are present on the platform, set up the LoRaWAN connection,
-	and (ultimately) return to the framework, which then calls loop()
-	forever.
+        This function is called by the Arduino framework after
+        basic framework has been initialized. We initialize the sensors
+        that are present on the platform, set up the LoRaWAN connection,
+        and (ultimately) return to the framework, which then calls loop()
+        forever.
 
 Returns:
-	No explicit result.
+        No explicit result.
 
 */
 
 void setup(void)
-	{
-	gCatena.begin();
+        {
+        gCatena.begin();
 
-	setup_platform();
-	setup_light();
-	setup_bme280();
-	setup_flash();
-	setup_uplink();
-	}
+        setup_platform();
+        setup_light();
+        setup_bme280();
+        setup_flash();
+        setup_uplink();
+        }
 
 void setup_platform(void)
         {
@@ -239,24 +239,24 @@ void setup_platform(void)
         gCatena.SafePrintf("(remember to select 'Line Ending: Newline' at the bottom of the monitor window.)\n");
 
 #ifdef CATENA_CFG_SYSCLK
-	gCatena.SafePrintf("SYSCLK: %d MHz\n", CATENA_CFG_SYSCLK);
+        gCatena.SafePrintf("SYSCLK: %d MHz\n", CATENA_CFG_SYSCLK);
 #endif
 
 #ifdef USBCON
-	gCatena.SafePrintf("USB enabled\n");
+        gCatena.SafePrintf("USB enabled\n");
 #else
-	gCatena.SafePrintf("USB disabled\n");
+        gCatena.SafePrintf("USB disabled\n");
 #endif
 
         gLoRaWAN.SetReceiveBufferBufferCb(receiveMessage);
         setTxCycleTime(CATCFG_T_CYCLE_INITIAL, CATCFG_INTERVAL_COUNT_INITIAL);
 
-	Catena::UniqueID_string_t CpuIDstring;
+        Catena::UniqueID_string_t CpuIDstring;
 
-	gCatena.SafePrintf(
-		"CPU Unique ID: %s\n",
-		gCatena.GetUniqueIDstring(&CpuIDstring)
-		);
+        gCatena.SafePrintf(
+                "CPU Unique ID: %s\n",
+                gCatena.GetUniqueIDstring(&CpuIDstring)
+                );
 
         gCatena.SafePrintf("--------------------------------------------------------------------------------\n");
         gCatena.SafePrintf("\n");
@@ -266,7 +266,7 @@ void setup_platform(void)
         gCatena.registerObject(&gLed);
         gLed.Set(LedPattern::FastFlash);
 
-	// set up LoRaWAN
+        // set up LoRaWAN
         gCatena.SafePrintf("LoRaWAN init: ");
         if (!gLoRaWAN.begin(&gCatena))
                 {
@@ -277,7 +277,7 @@ void setup_platform(void)
                 gCatena.SafePrintf("succeeded\n");
                 }
 
-	gCatena.registerObject(&gLoRaWAN);
+        gCatena.registerObject(&gLoRaWAN);
 
         /* find the platform */
         const Catena::EUI64_buffer_t *pSysEUI = gCatena.GetSysEUI();
@@ -308,58 +308,58 @@ void setup_platform(void)
                 gCatena.SafePrintf("**** no platform, check provisioning ****\n");
                 flags = 0;
                 }
-	}
+        }
 
 void setup_light(void)
-	{
-	if (gSi1133.begin())
-		{
-		fLight = true;
-		gSi1133.configure(0, CATENA_SI1133_MODE_SmallIR);
-		gSi1133.configure(1, CATENA_SI1133_MODE_White);
-		gSi1133.configure(2, CATENA_SI1133_MODE_UV);
-		gSi1133.start();
-		}
-	else
-		{
-		fLight = false;
-		gCatena.SafePrintf("No Si1133 found: check hardware\n");
-		}
+        {
+        if (gSi1133.begin())
+                {
+                fLight = true;
+                gSi1133.configure(0, CATENA_SI1133_MODE_SmallIR);
+                gSi1133.configure(1, CATENA_SI1133_MODE_White);
+                gSi1133.configure(2, CATENA_SI1133_MODE_UV);
+                gSi1133.start();
+                }
+        else
+                {
+                fLight = false;
+                gCatena.SafePrintf("No Si1133 found: check hardware\n");
+                }
         }
 
 void setup_bme280(void)
-	{
-	if (gBME280.begin(BME280_ADDRESS, Adafruit_BME280::OPERATING_MODE::Sleep))
-		{
-		fBme = true;
-		}
-	else
-		{
-		fBme = false;
-		gCatena.SafePrintf("No BME280 found: check wiring\n");
-		}
-	}
+        {
+        if (gBME280.begin(BME280_ADDRESS, Adafruit_BME280::OPERATING_MODE::Sleep))
+                {
+                fBme = true;
+                }
+        else
+                {
+                fBme = false;
+                gCatena.SafePrintf("No BME280 found: check wiring\n");
+                }
+        }
 
 void setup_flash(void)
-	{
-	if (gFlash.begin(&gSPI2, Catena::PIN_SPI2_FLASH_SS))
-		{
-		fFlash = true;
-		gFlash.powerDown();
-		gCatena.SafePrintf("FLASH found, put power down\n");
-		}
-	else
-		{
-		fFlash = false;
-		gFlash.end();
-		gSPI2.end();
-		gCatena.SafePrintf("No FLASH found: check hardware\n");
-		}
-	}
+        {
+        if (gFlash.begin(&gSPI2, Catena::PIN_SPI2_FLASH_SS))
+                {
+                fFlash = true;
+                gFlash.powerDown();
+                gCatena.SafePrintf("FLASH found, put power down\n");
+                }
+        else
+                {
+                fFlash = false;
+                gFlash.end();
+                gSPI2.end();
+                gCatena.SafePrintf("No FLASH found: check hardware\n");
+                }
+        }
 
 void setup_uplink(void)
-	{
-	LMIC_setClockError(10*65536/100);
+        {
+        LMIC_setClockError(10*65536/100);
 
         /* trigger a join by sending the first packet */
         if (!(gCatena.GetOperatingFlags() &
@@ -396,90 +396,90 @@ void loop()
                 {
                 TxBuffer_t b;
                 fillBuffer(b);
-		gSi1133.start();
+                gSi1133.start();
                 delay(1000);
-		// since the light sensor was stopped in fillbuffer, restart it.
+                // since the light sensor was stopped in fillbuffer, restart it.
                 }
         }
 
 void fillBuffer(TxBuffer_t &b)
-	{
-	b.begin();
-	FlagsSensorPort2 flag;
+        {
+        b.begin();
+        FlagsSensorPort2 flag;
 
-	flag = FlagsSensorPort2(0);
+        flag = FlagsSensorPort2(0);
 
-	// we have no format byte for this.
-	uint8_t * const pFlag = b.getp();
-	b.put(0x00); /* will be set to the flags */
+        // we have no format byte for this.
+        uint8_t * const pFlag = b.getp();
+        b.put(0x00); /* will be set to the flags */
 
-	// vBat is sent as 5000 * v
-	float vBat = gCatena.ReadVbat();
-	gCatena.SafePrintf("vBat:    %d mV\n", (int) (vBat * 1000.0f));
-	b.putV(vBat);
-	flag |= FlagsSensorPort2::FlagVbat;
+        // vBat is sent as 5000 * v
+        float vBat = gCatena.ReadVbat();
+        gCatena.SafePrintf("vBat:    %d mV\n", (int) (vBat * 1000.0f));
+        b.putV(vBat);
+        flag |= FlagsSensorPort2::FlagVbat;
 
-	// vBus is sent as 5000 * v
-	float vBus = gCatena.ReadVbus();
-	gCatena.SafePrintf("vBus:    %d mV\n", (int) (vBus * 1000.0f));
-	fUsbPower = (vBus > 3.0) ? true : false;
+        // vBus is sent as 5000 * v
+        float vBus = gCatena.ReadVbus();
+        gCatena.SafePrintf("vBus:    %d mV\n", (int) (vBus * 1000.0f));
+        fUsbPower = (vBus > 3.0) ? true : false;
 
-	uint32_t bootCount;
-	if (gCatena.getBootCount(bootCount))
-		{
-		b.putBootCountLsb(bootCount);
-		flag |= FlagsSensorPort2::FlagBoot;
-		}
+        uint32_t bootCount;
+        if (gCatena.getBootCount(bootCount))
+                {
+                b.putBootCountLsb(bootCount);
+                flag |= FlagsSensorPort2::FlagBoot;
+                }
 
-	if (fBme)
-		{
-		Adafruit_BME280::Measurements m = gBME280.readTemperaturePressureHumidity();
-		// temperature is 2 bytes from -0x80.00 to +0x7F.FF degrees C
-		// pressure is 2 bytes, hPa * 10.
-		// humidity is one byte, where 0 == 0/256 and 0xFF == 255/256.
-		gCatena.SafePrintf(
-		        "BME280:  T: %d P: %d RH: %d\n",
-		        (int) m.Temperature,
-		        (int) m.Pressure,
-		        (int) m.Humidity
-		        );
-		b.putT(m.Temperature);
-		b.putP(m.Pressure);
-		b.putRH(m.Humidity);
+        if (fBme)
+                {
+                Adafruit_BME280::Measurements m = gBME280.readTemperaturePressureHumidity();
+                // temperature is 2 bytes from -0x80.00 to +0x7F.FF degrees C
+                // pressure is 2 bytes, hPa * 10.
+                // humidity is one byte, where 0 == 0/256 and 0xFF == 255/256.
+                gCatena.SafePrintf(
+                        "BME280:  T: %d P: %d RH: %d\n",
+                        (int) m.Temperature,
+                        (int) m.Pressure,
+                        (int) m.Humidity
+                        );
+                b.putT(m.Temperature);
+                b.putP(m.Pressure);
+                b.putRH(m.Humidity);
 
-		flag |= FlagsSensorPort2::FlagTPH;
-		}
+                flag |= FlagsSensorPort2::FlagTPH;
+                }
 
-	if (fLight)
-		{
-		/* Get a new sensor event */
-		uint16_t data[3];
+        if (fLight)
+                {
+                /* Get a new sensor event */
+                uint16_t data[3];
 
-		gSi1133.readMultiChannelData(data, 3);
-		gSi1133.stop();
-		gCatena.SafePrintf(
-			"Si1133:  %u IR, %u White, %u UV\n",
-			data[0],
-			data[1],
-			data[2]
-			);
+                gSi1133.readMultiChannelData(data, 3);
+                gSi1133.stop();
+                gCatena.SafePrintf(
+                        "Si1133:  %u IR, %u White, %u UV\n",
+                        data[0],
+                        data[1],
+                        data[2]
+                        );
 
-		b.putLux(data[0]);
-		b.putLux(data[1]);
-		b.putLux(data[2]);
+                b.putLux(data[0]);
+                b.putLux(data[1]);
+                b.putLux(data[2]);
 
-		flag |= FlagsSensorPort2::FlagLight;
-		}
+                flag |= FlagsSensorPort2::FlagLight;
+                }
 
-	b.putV(vBus);
-	flag |= FlagsSensorPort2::FlagVbus;
+        b.putV(vBus);
+        flag |= FlagsSensorPort2::FlagVbus;
 
-	*pFlag = uint8_t(flag);
-	}
+        *pFlag = uint8_t(flag);
+        }
 
 void startSendingUplink(void)
-	{
-	TxBuffer_t b;
+        {
+        TxBuffer_t b;
         LedPattern savedLed = gLed.Set(LedPattern::Measuring);
 
         fillBuffer(b);
@@ -490,7 +490,7 @@ void startSendingUplink(void)
 
         bool fConfirmed = false;
         if (gCatena.GetOperatingFlags() &
-		static_cast<uint32_t>(gCatena.OPERATING_FLAGS::fConfirmedUplink))
+                static_cast<uint32_t>(gCatena.OPERATING_FLAGS::fConfirmedUplink))
                 {
                 gCatena.SafePrintf("requesting confirmed tx\n");
                 fConfirmed = true;
@@ -500,16 +500,16 @@ void startSendingUplink(void)
         }
 
 static void sendBufferDoneCb(
-	void *pContext,
-	bool fStatus
-	)
-	{
-	osjobcb_t pFn;
+        void *pContext,
+        bool fStatus
+        )
+        {
+        osjobcb_t pFn;
 
-	gLed.Set(LedPattern::Settling);
+        gLed.Set(LedPattern::Settling);
         pFn = settleDoneCb;
-	if (! fStatus)
-		{
+        if (! fStatus)
+                {
                 if (!gLoRaWAN.IsProvisioned())
                         {
                         // we'll talk about it at the callback.
@@ -517,47 +517,47 @@ static void sendBufferDoneCb(
                         }
                 else
                         gCatena.SafePrintf("send buffer failed\n");
-		}
+                }
 
-	os_setTimedCallback(
-		&sensorJob,
-		os_getTime()+sec2osticks(CATCFG_T_SETTLE),
-		pFn
-		);
-	}
+        os_setTimedCallback(
+                &sensorJob,
+                os_getTime()+sec2osticks(CATCFG_T_SETTLE),
+                pFn
+                );
+        }
 
 static void txNotProvisionedCb(
-	osjob_t *pSendJob
-	)
-	{
+        osjob_t *pSendJob
+        )
+        {
         gCatena.SafePrintf("LoRaWAN not provisioned yet. Use the commands to set it up.\n");
         gLoRaWAN.Shutdown();
-	gLed.Set(LedPattern::NotProvisioned);
-	}
+        gLed.Set(LedPattern::NotProvisioned);
+        }
 
 
 static void settleDoneCb(
-	osjob_t *pSendJob
-	)
-	{
-	const bool fDeepSleep = checkDeepSleep();
+        osjob_t *pSendJob
+        )
+        {
+        const bool fDeepSleep = checkDeepSleep();
 
-	if (! g_fPrintedSleeping)
-		doSleepAlert(fDeepSleep);
+        if (! g_fPrintedSleeping)
+                doSleepAlert(fDeepSleep);
 
-	/* count what we're up to */
-	updateSleepCounters();
+        /* count what we're up to */
+        updateSleepCounters();
 
-	if (fDeepSleep)
-		doDeepSleep(pSendJob);
-	else
-		doLightSleep(pSendJob);
-	}
+        if (fDeepSleep)
+                doDeepSleep(pSendJob);
+        else
+                doLightSleep(pSendJob);
+        }
 
 bool checkDeepSleep(void)
-	{
+        {
         bool const fDeepSleepTest = gCatena.GetOperatingFlags() &
-			static_cast<uint32_t>(gCatena.OPERATING_FLAGS::fDeepSleepTest);
+                        static_cast<uint32_t>(gCatena.OPERATING_FLAGS::fDeepSleepTest);
         bool fDeepSleep;
 
         if (fDeepSleepTest)
@@ -570,8 +570,8 @@ bool checkDeepSleep(void)
                 fDeepSleep = false;
                 }
 #endif
-	else if (gCatena.GetOperatingFlags() &
-			static_cast<uint32_t>(gCatena.OPERATING_FLAGS::fDisableDeepSleep))
+        else if (gCatena.GetOperatingFlags() &
+                        static_cast<uint32_t>(gCatena.OPERATING_FLAGS::fDisableDeepSleep))
                 {
                 fDeepSleep = false;
                 }
@@ -585,55 +585,55 @@ bool checkDeepSleep(void)
                 fDeepSleep = false;
                 }
 
-	return fDeepSleep;
-	}
+        return fDeepSleep;
+        }
 
 void doSleepAlert(const bool fDeepSleep)
-	{
-	g_fPrintedSleeping = true;
+        {
+        g_fPrintedSleeping = true;
 
-	if (fDeepSleep)
-		{
-        	bool const fDeepSleepTest = gCatena.GetOperatingFlags() &
-				static_cast<uint32_t>(gCatena.OPERATING_FLAGS::fDeepSleepTest);
-		const uint32_t deepSleepDelay = fDeepSleepTest ? 10 : 30;
+        if (fDeepSleep)
+                {
+                bool const fDeepSleepTest = gCatena.GetOperatingFlags() &
+                                static_cast<uint32_t>(gCatena.OPERATING_FLAGS::fDeepSleepTest);
+                const uint32_t deepSleepDelay = fDeepSleepTest ? 10 : 30;
 
-		gCatena.SafePrintf("using deep sleep in %u secs"
+                gCatena.SafePrintf("using deep sleep in %u secs"
 #ifdef USBCON
-				   " (USB will disconnect while asleep)"
+                                   " (USB will disconnect while asleep)"
 #endif
-				   ": ",
-					deepSleepDelay
-					);
+                                   ": ",
+                                        deepSleepDelay
+                                        );
 
-		// sleep and print
-		gLed.Set(LedPattern::TwoShort);
+                // sleep and print
+                gLed.Set(LedPattern::TwoShort);
 
-		for (auto n = deepSleepDelay; n > 0; --n)
-			{
-			uint32_t tNow = millis();
+                for (auto n = deepSleepDelay; n > 0; --n)
+                        {
+                        uint32_t tNow = millis();
 
-			while (uint32_t(millis() - tNow) < 1000)
-				{
-				gCatena.poll();
-				yield();
-				}
-			gCatena.SafePrintf(".");
-			}
-		gCatena.SafePrintf("\nStarting deep sleep.\n");
-		uint32_t tNow = millis();
-		while (uint32_t(millis() - tNow) < 100)
-			{
-			gCatena.poll();
-			yield();
-			}
-		}
-	else
-		gCatena.SafePrintf("using light sleep\n");
-	}
+                        while (uint32_t(millis() - tNow) < 1000)
+                                {
+                                gCatena.poll();
+                                yield();
+                                }
+                        gCatena.SafePrintf(".");
+                        }
+                gCatena.SafePrintf("\nStarting deep sleep.\n");
+                uint32_t tNow = millis();
+                while (uint32_t(millis() - tNow) < 100)
+                        {
+                        gCatena.poll();
+                        yield();
+                        }
+                }
+        else
+                gCatena.SafePrintf("using light sleep\n");
+        }
 
 void updateSleepCounters(void)
-	{
+        {
         // update the sleep parameters
         if (gTxCycleCount > 1)
                 --gTxCycleCount;
@@ -645,88 +645,88 @@ void updateSleepCounters(void)
                 gTxCycleCount = 0;
                 gTxCycle = CATCFG_T_CYCLE;
                 }
-	}
+        }
 
 void doDeepSleep(osjob_t *pJob)
-	{
+        {
         bool const fDeepSleepTest = gCatena.GetOperatingFlags() &
-				static_cast<uint32_t>(gCatena.OPERATING_FLAGS::fDeepSleepTest);
+                                static_cast<uint32_t>(gCatena.OPERATING_FLAGS::fDeepSleepTest);
         uint32_t const sleepInterval = CATCFG_GetInterval(
                         fDeepSleepTest ? CATCFG_T_CYCLE_TEST : gTxCycle
                         );
 
-	/* ok... now it's time for a deep sleep */
-	gLed.Set(LedPattern::Off);
-	deepSleepPrepare();
+        /* ok... now it's time for a deep sleep */
+        gLed.Set(LedPattern::Off);
+        deepSleepPrepare();
 
-	/* sleep */
-	gCatena.Sleep(sleepInterval);
+        /* sleep */
+        gCatena.Sleep(sleepInterval);
 
-	/* recover from sleep */
-	deepSleepRecovery();
+        /* recover from sleep */
+        deepSleepRecovery();
 
-	/* and now... we're awake again. trigger another measurement */
-	sleepDoneCb(pJob);
-	}
+        /* and now... we're awake again. trigger another measurement */
+        sleepDoneCb(pJob);
+        }
 
 void deepSleepPrepare(void)
-	{
-	Serial.end();
-	Wire.end();
-	SPI.end();
-	if (fFlash)
-		gSPI2.end();
-	}
+        {
+        Serial.end();
+        Wire.end();
+        SPI.end();
+        if (fFlash)
+                gSPI2.end();
+        }
 
 void deepSleepRecovery(void)
-	{
-	Serial.begin();
-	Wire.begin();
-	SPI.begin();
-	if (fFlash)
-		gSPI2.begin();
-	}
+        {
+        Serial.begin();
+        Wire.begin();
+        SPI.begin();
+        if (fFlash)
+                gSPI2.begin();
+        }
 
 void doLightSleep(osjob_t *pJob)
-	{
-	uint32_t interval = sec2osticks(CATCFG_GetInterval(gTxCycle));
+        {
+        uint32_t interval = sec2osticks(CATCFG_GetInterval(gTxCycle));
 
-	gLed.Set(LedPattern::Sleeping);
+        gLed.Set(LedPattern::Sleeping);
 
-	if (gCatena.GetOperatingFlags() &
-		static_cast<uint32_t>(gCatena.OPERATING_FLAGS::fQuickLightSleep))
-		{
-		interval = 1;
-		}
+        if (gCatena.GetOperatingFlags() &
+                static_cast<uint32_t>(gCatena.OPERATING_FLAGS::fQuickLightSleep))
+                {
+                interval = 1;
+                }
 
-	gLed.Set(LedPattern::Sleeping);
-	os_setTimedCallback(
-		&sensorJob,
-		os_getTime() + interval,
-		sleepDoneCb
-		);
-	}
+        gLed.Set(LedPattern::Sleeping);
+        os_setTimedCallback(
+                &sensorJob,
+                os_getTime() + interval,
+                sleepDoneCb
+                );
+        }
 
 static void sleepDoneCb(
-	osjob_t *pJob
-	)
-	{
-	gLed.Set(LedPattern::WarmingUp);
-	gSi1133.start();
+        osjob_t *pJob
+        )
+        {
+        gLed.Set(LedPattern::WarmingUp);
+        gSi1133.start();
 
-	os_setTimedCallback(
-		&sensorJob,
-		os_getTime() + sec2osticks(CATCFG_T_WARMUP),
-		warmupDoneCb
-		);
-	}
+        os_setTimedCallback(
+                &sensorJob,
+                os_getTime() + sec2osticks(CATCFG_T_WARMUP),
+                warmupDoneCb
+                );
+        }
 
 static void warmupDoneCb(
-	osjob_t *pJob
-	)
-	{
-	startSendingUplink();
-	}
+        osjob_t *pJob
+        )
+        {
+        startSendingUplink();
+        }
 
 static void receiveMessage(
         void *pContext,
@@ -738,11 +738,11 @@ static void receiveMessage(
         unsigned txCycle;
         unsigned txCount;
 
-	if (port == 0)
-		{
-		// mac downlink mesage; do nothing.
-		return;
-		}
+        if (port == 0)
+                {
+                // mac downlink mesage; do nothing.
+                return;
+                }
         else if (! (port == 1 && 2 <= nMessage && nMessage <= 3))
                 {
                 gCatena.SafePrintf("invalid message port(%02x)/length(%x)\n",


### PR DESCRIPTION
During the last network failure, 5 out of 6 Catena 4612 units running catena4612_simple ended up in teh three-flash state. Investigation revealed that the problem was likely due to an uplink returning failure status, which was incorrectly interpreted as "not provisioned".  This fix isn't the whole story -- not clear why this came back, but it was the old LMIC.