### PR TITLE
Fix #80: missing default value

### DIFF
--- a/catena4450m102_pond/catena4450m102_pond.ino
+++ b/catena4450m102_pond/catena4450m102_pond.ino
@@ -613,6 +613,7 @@ static void sendBufferDoneCb(
 
         gLed.Set(LedPattern::Settling);
 
+        pFn = settleDoneCb;
         if (!fStatus)
                {
                 if (!gLoRaWAN.IsProvisioned())

--- a/catena4450m102_waterlevel/catena4450m102_waterlevel.ino
+++ b/catena4450m102_waterlevel/catena4450m102_waterlevel.ino
@@ -593,6 +593,7 @@ static void sendBufferDoneCb(
 
     gLed.Set(LedPattern::Settling);
 
+    pFn = settleDoneCb;
     if (!fStatus)
         {
         if (!gLoRaWAN.IsProvisioned())

--- a/catena4460_aqi/catena4460_aqi.ino
+++ b/catena4460_aqi/catena4460_aqi.ino
@@ -422,6 +422,7 @@ static void sendBufferDoneCb(
 
     gLed.Set(LedPattern::Settling);
 
+    pFn = settleDoneCb;
     if (!fStatus)
         {
         if (!gLoRaWAN.IsProvisioned())

--- a/catena4460_bsec_ulp/catena4460_bsec_ulp.ino
+++ b/catena4460_bsec_ulp/catena4460_bsec_ulp.ino
@@ -679,6 +679,7 @@ static void sendBufferDoneCb(
 
         gLed.Set(LedPattern::Settling);
 
+        pFn = settleDoneCb;
         if (!fStatus)
                {
                 if (!gLoRaWAN.IsProvisioned())

--- a/catena4551_test01/catena4551_test01.ino
+++ b/catena4551_test01/catena4551_test01.ino
@@ -667,6 +667,7 @@ static void sendBufferDoneCb(
 
 	gLed.Set(LedPattern::Settling);
 
+        pFn = settleDoneCb;
         if (!fStatus)
                {
                 if (!gLoRaWAN.IsProvisioned())

--- a/catena4612_simple/catena4612_simple.ino
+++ b/catena4612_simple/catena4612_simple.ino
@@ -507,6 +507,7 @@ static void sendBufferDoneCb(
         osjobcb_t pFn;
 
         gLed.Set(LedPattern::Settling);
+
         pFn = settleDoneCb;
         if (! fStatus)
                 {

--- a/catena461x_test01/catena461x_test01.ino
+++ b/catena461x_test01/catena461x_test01.ino
@@ -652,6 +652,7 @@ static void sendBufferDoneCb(
 
 	gLed.Set(LedPattern::Settling);
 
+        pFn = settleDoneCb;
         if (!fStatus)
                {
                 if (!gLoRaWAN.IsProvisioned())


### PR DESCRIPTION
I screwed up the cut and paste for #77.

While reviewing, adjusted whitespace to make these identical.

This logic all should be centralized so it doesn't have to be fixed N places.  See #81.