### PR TITLE
Fix #112: rename MCCI Adafruit_FRAM_I2C lib to MCCI_FRAM_I2C

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ before_install:
 install:
  - _clonelib github.com mcci-catena/Adafruit_BME280_Library
  - _clonelib github.com mcci-catena/Adafruit_BME680
- - _clonelib github.com mcci-catena/Adafruit_FRAM_I2C
+ - _clonelib github.com mcci-catena/MCCI_FRAM_I2C
  - _clonelib github.com mcci-catena/Adafruit_Sensor
  - _clonelib github.com mcci-catena/Adafruit_TSL2561
  - _clonelib github.com mcci-catena/Arduino-Temperature-Control-Library

--- a/catena4450_test01/catena4450_test01.ino
+++ b/catena4450_test01/catena4450_test01.ino
@@ -36,7 +36,7 @@ Revision history:
 #include <BH1750.h>
 #include <stdio.h>
 #include <stdarg.h>
-#include <Adafruit_FRAM_I2C.h>
+#include <MCCI_FRAM_I2C.h>
 #include <Catena4450.h>
 
 /****************************************************************************\

--- a/catena4450m101_sensor/README.md
+++ b/catena4450m101_sensor/README.md
@@ -97,7 +97,7 @@ It's easy to run, provided you're on Windows, macOS, or Linux, and provided you 
 ```console
 $ cd Catena4410-Sketches/catena4450m101_sensor
 $ ../git-boot.sh
-Cloning into 'Adafruit_FRAM_I2C'...
+Cloning into 'MCCI_FRAM_I2C'...
 remote: Counting objects: 96, done.
 remote: Total 96 (delta 0), reused 0 (delta 0), pack-reused 96
 Unpacking objects: 100% (96/96), done.
@@ -145,7 +145,7 @@ Unpacking objects: 100% (58/58), done.
 No repos with errors
 No repos skipped.
 *** no repos were pulled ***
-Repos downloaded:      Adafruit_FRAM_I2C Catena-Arduino-Platform arduino-lorawan Catena-mcciadk arduino-lmic Adafruit_BME280_Library Adafruit_Sensor RTCZero BH1750
+Repos downloaded:      MCCI_FRAM_I2C Catena-Arduino-Platform arduino-lorawan Catena-mcciadk arduino-lmic Adafruit_BME280_Library Adafruit_Sensor RTCZero BH1750
 ```
 
 It has a number of advanced options; use `../git-boot.sh -h` to get help, or look at the source code [here](https://github.com/mcci-catena/Catena-Sketches/blob/master/git-boot.sh).
@@ -156,7 +156,7 @@ It has a number of advanced options; use `../git-boot.sh -h` to get help, or loo
 
 This sketch depends on the following libraries.
 
-* [github.com/mcci-catena/Adafruit_FRAM_I2C](https://github.com/mcci-catena/Adafruit_FRAM_I2C)
+* [github.com/mcci-catena/MCCI_FRAM_I2C](https://github.com/mcci-catena/MCCI_FRAM_I2C)
 * [github.com/mcci-catena/Catena4410-Arduino-Library](https://github.com/mcci-catena/Catena4410-Arduino-Library)
 * [github.com/mcci-catena/arduino-lorawan](https://github.com/mcci-catena/arduino-lorawan)
 * [github.com/mcci-catena/Catena-mcciadk](https://github.com/mcci-catena/Catena-mcciadk)

--- a/catena4450m101_sensor/git-repos.dat
+++ b/catena4450m101_sensor/git-repos.dat
@@ -1,7 +1,7 @@
 #
 # list of git repositories to be fetched to Arduino libraries directory.
 #
-github.com	mcci-catena/Adafruit_FRAM_I2C.git
+github.com	mcci-catena/MCCI_FRAM_I2C.git
 github.com	mcci-catena/Catena-Arduino-Platform.git
 github.com	mcci-catena/arduino-lorawan.git
 github.com	mcci-catena/Catena-mcciadk.git

--- a/catena4450m102_pond/git-repos.dat
+++ b/catena4450m102_pond/git-repos.dat
@@ -1,7 +1,7 @@
 #
 # list of git repositories to be fetched to Arduino libraries directory.
 #
-github.com	mcci-catena/Adafruit_FRAM_I2C.git
+github.com	mcci-catena/MCCI_FRAM_I2C.git
 github.com	mcci-catena/Catena-Arduino-Platform.git
 github.com	mcci-catena/arduino-lorawan.git
 github.com	mcci-catena/Catena-mcciadk.git

--- a/catena4460_aqi/git-repos.dat
+++ b/catena4460_aqi/git-repos.dat
@@ -2,7 +2,7 @@
 # list of git repositories needed by this directory.
 # Use ../git-boot.sh to be fetch them to the Arduino libraries directory.
 #
-github.com	mcci-catena/Adafruit_FRAM_I2C.git
+github.com	mcci-catena/MCCI_FRAM_I2C.git
 github.com	mcci-catena/Catena-Arduino-Platform.git
 github.com	mcci-catena/arduino-lorawan.git
 github.com	mcci-catena/Catena-mcciadk.git

--- a/catena4470_test01/README.md
+++ b/catena4470_test01/README.md
@@ -88,7 +88,7 @@ remote: Enumerating objects: 134, done.
 remote: Total 134 (delta 0), reused 0 (delta 0), pack-reused 134
 Receiving objects: 100% (134/134), 39.31 KiB | 1.46 MiB/s, done.
 Resolving deltas: 100% (68/68), done.
-Cloning into 'Adafruit_FRAM_I2C'...
+Cloning into 'MCCI_FRAM_I2C'...
 remote: Enumerating objects: 96, done.
 remote: Total 96 (delta 0), reused 0 (delta 0), pack-reused 96
 Unpacking objects: 100% (96/96), done.
@@ -146,7 +146,7 @@ Checking out files: 100% (44/44), done.
 
 New repos cloned:
 Adafruit_BME280_Library BH1750                  Modbus-for-Arduino
-Adafruit_FRAM_I2C       Catena-Arduino-Platform arduino-lmic
+MCCI_FRAM_I2C           Catena-Arduino-Platform arduino-lmic
 Adafruit_Sensor         Catena-mcciadk          arduino-lorawan
 ```
 
@@ -159,7 +159,7 @@ It has a number of advanced options; use `../git-boot.sh -h` to get help, or loo
 This sketch depends on the following libraries.
 
 *  https://github.com/mcci-catena/Adafruit_BME280_Library
-*  https://github.com/mcci-catena/Adafruit_FRAM_I2C
+*  https://github.com/mcci-catena/MCCI_FRAM_I2C
 *  https://github.com/mcci-catena/Adafruit_Sensor
 *  https://github.com/mcci-catena/arduino-lmic
 *  https://github.com/mcci-catena/arduino-lorawan

--- a/catena4470_test01/git-repos.dat
+++ b/catena4470_test01/git-repos.dat
@@ -2,7 +2,7 @@
 # list of git repositories to be fetched to Arduino libraries directory.
 #
 github.com	mcci-catena/Adafruit_BME280_Library.git
-github.com	mcci-catena/Adafruit_FRAM_I2C.git
+github.com	mcci-catena/MCCI_FRAM_I2C.git
 github.com	mcci-catena/Adafruit_Sensor.git
 github.com	mcci-catena/arduino-lmic.git
 github.com	mcci-catena/arduino-lorawan.git

--- a/catena4551_test01/README.md
+++ b/catena4551_test01/README.md
@@ -4,20 +4,20 @@
 
 - [Introduction](#introduction)
 - [Getting Started](#getting-started)
-	- [Clone this repository into a suitable directory on your system](#clone-this-repository-into-a-suitable-directory-on-your-system)
-	- [Install the MCCI STM32 board support library](#install-the-mcci-stm32-board-support-library)
-	- [Select your desired band](#select-your-desired-band)
-	- [Installing the required libraries](#installing-the-required-libraries)
-		- [List of required libraries](#list-of-required-libraries)
-	- [Build and Download](#build-and-download)
-	- [Load the sketch into the Catena](#load-the-sketch-into-the-catena)
+    - [Clone this repository into a suitable directory on your system](#clone-this-repository-into-a-suitable-directory-on-your-system)
+    - [Install the MCCI STM32 board support library](#install-the-mcci-stm32-board-support-library)
+    - [Select your desired band](#select-your-desired-band)
+    - [Installing the required libraries](#installing-the-required-libraries)
+        - [List of required libraries](#list-of-required-libraries)
+    - [Build and Download](#build-and-download)
+    - [Load the sketch into the Catena](#load-the-sketch-into-the-catena)
 - [Provision your Catena 4551](#provision-your-catena-4551)
 - [Notes](#notes)
-	- [Setting up DFU on a Linux or Windows PC](#setting-up-dfu-on-a-linux-or-windows-pc)
-	- [Data Format](#data-format)
-	- [Unplugging the USB Cable while running on batteries](#unplugging-the-usb-cable-while-running-on-batteries)
-	- [Deep sleep and USB](#deep-sleep-and-usb)
-	- [gitboot.sh and the other sketches](#gitbootsh-and-the-other-sketches)
+    - [Setting up DFU on a Linux or Windows PC](#setting-up-dfu-on-a-linux-or-windows-pc)
+    - [Data Format](#data-format)
+    - [Unplugging the USB Cable while running on batteries](#unplugging-the-usb-cable-while-running-on-batteries)
+    - [Deep sleep and USB](#deep-sleep-and-usb)
+    - [gitboot.sh and the other sketches](#gitbootsh-and-the-other-sketches)
 
 <!-- /TOC -->
 
@@ -126,7 +126,7 @@ Resolving deltas: 100% (900/900), done.
 
 New repos cloned:
 Adafruit_BME280_Library                 Catena-mcciadk
-Adafruit_FRAM_I2C                       OneWire
+MCCI_FRAM_I2C                           OneWire
 Arduino-Temperature-Control-Library     arduino-lmic
 Catena-Arduino-Platform                 arduino-lorawan
 SHT1x
@@ -144,7 +144,7 @@ This sketch depends on the following libraries.
 * [`github.com/mcci-catena/arduino-lorawan`](https://github.com/mcci-catena/arduino-lorawan)
 * [`github.com/mcci-catena/Catena-mcciadk`](https://github.com/mcci-catena/Catena-mcciadk)
 * [`github.com/mcci-catena/arduino-lmic`](https://github.com/mcci-catena/arduino-lmic)
-* [`github.com/mcci-catena/Adafruit_FRAM_I2C`](https://github.com/mcci-catena/Adafruit_FRAM_I2C)
+* [`github.com/mcci-catena/MCCI_FRAM_I2C`](https://github.com/mcci-catena/MCCI_FRAM_I2C)
 * [`github.com/mcci-catena/Adafruit_BME280_Library`](https://github.com/mcci-catena/Adafruit_BME280_Library)
 * [`github.com/mcci-catena/Arduino-Temperature-Control-Library`](https://github.com/mcci-catena/Arduino-Temperature-Control-Library)
 * [`github.com/mcci-catena/OneWire`](https://github.com/mcci-catena/OneWire)

--- a/catena4551_test01/git-repos.dat
+++ b/catena4551_test01/git-repos.dat
@@ -5,7 +5,7 @@ github.com	mcci-catena/Catena-Arduino-Platform.git
 github.com	mcci-catena/arduino-lorawan.git
 github.com	mcci-catena/Catena-mcciadk.git
 github.com	mcci-catena/arduino-lmic.git
-github.com	mcci-catena/Adafruit_FRAM_I2C.git
+github.com	mcci-catena/MCCI_FRAM_I2C.git
 github.com	mcci-catena/Adafruit_BME280_Library.git
 github.com	mcci-catena/Arduino-Temperature-Control-Library.git
 github.com	mcci-catena/OneWire.git

--- a/catena4551_test02/README.md
+++ b/catena4551_test02/README.md
@@ -116,9 +116,9 @@ Resolving deltas: 100% (900/900), done.
 
 New repos cloned:
 Adafruit_BME280_Library                 Catena-mcciadk
-Adafruit_FRAM_I2C                       OneWire
+MCCI_FRAM_I2C                           OneWire
 Arduino-Temperature-Control-Library     SHT1x
-Catena-Arduino-Platform                 BH1750                                   
+Catena-Arduino-Platform                 BH1750
 ```
 
 It has a number of advanced options; use `../git-boot.sh -h` to get help, or look at the source code [here](https://github.com/mcci-catena/Catena-Sketches/blob/master/git-boot.sh).

--- a/catena4551_test02/catena4551_test02.ino
+++ b/catena4551_test02/catena4551_test02.ino
@@ -36,7 +36,7 @@ Revision history:
 #include <BH1750.h>
 #include <stdio.h>
 #include <stdarg.h>
-//#include <Adafruit_FRAM_I2C.h>
+//#include <MCCI_FRAM_I2C.h>
 #include <Catena.h>
 #include <OneWire.h>
 #include <DallasTemperature.h>

--- a/catena4551_test02/git-repos.dat
+++ b/catena4551_test02/git-repos.dat
@@ -5,7 +5,7 @@ github.com	mcci-catena/Catena-Arduino-Platform.git
 github.com	mcci-catena/arduino-lorawan.git
 github.com	mcci-catena/Catena-mcciadk.git
 github.com	mcci-catena/arduino-lmic.git
-github.com	mcci-catena/Adafruit_FRAM_I2C.git
+github.com	mcci-catena/MCCI_FRAM_I2C.git
 github.com	mcci-catena/Adafruit_BME280_Library.git
 github.com	mcci-catena/Arduino-Temperature-Control-Library.git
 github.com	mcci-catena/BH1750.git

--- a/catena4612_simple/README.md
+++ b/catena4612_simple/README.md
@@ -150,7 +150,7 @@ Resolving deltas: 100% (900/900), done.
 No repos with errors
 No repos skipped.
 *** no repos were pulled ***
-Repos downloaded:      Catena-Arduino-Platform arduino-lorawan Catena-mcciadk arduino-lmic Adafruit_FRAM_I2C MCCI-Catena-HS300x
+Repos downloaded:      Catena-Arduino-Platform arduino-lorawan Catena-mcciadk arduino-lmic MCCI_FRAM_I2C MCCI-Catena-HS300x
 ```
 
 It has a number of advanced options; use `../git-boot.sh -h` to get help, or look at the source code [here](https://github.com/mcci-catena/Catena-Sketches/blob/master/git-boot.sh).
@@ -165,7 +165,7 @@ This sketch depends on the following libraries.
 * [`github.com/mcci-catena/arduino-lorawan`](https://github.com/mcci-catena/arduino-lorawan)
 * [`github.com/mcci-catena/Catena-mcciadk`](https://github.com/mcci-catena/Catena-mcciadk)
 * [`github.com/mcci-catena/arduino-lmic`](https://github.com/mcci-catena/arduino-lmic)
-* [`github.com/mcci-catena/Adafruit_FRAM_I2C`](https://github.com/mcci-catena/Adafruit_FRAM_I2C)
+* [`github.com/mcci-catena/MCCI_FRAM_I2C`](https://github.com/mcci-catena/MCCI_FRAM_I2C)
 * [`github.com/mcci-catena/MCCI-Catena-HS300x`](https://github.com/mcci-catena/MCCI-Catena-HS300x)
 
 ### Build and Download

--- a/catena4612_simple/git-repos.dat
+++ b/catena4612_simple/git-repos.dat
@@ -5,5 +5,5 @@ github.com	mcci-catena/Catena-Arduino-Platform.git
 github.com	mcci-catena/arduino-lorawan.git
 github.com	mcci-catena/Catena-mcciadk.git
 github.com	mcci-catena/arduino-lmic.git
-github.com	mcci-catena/Adafruit_FRAM_I2C.git
+github.com	mcci-catena/MCCI_FRAM_I2C.git
 github.com	mcci-catena/Adafruit_BME280_Library.git

--- a/catena4617_simple/README.md
+++ b/catena4617_simple/README.md
@@ -122,7 +122,7 @@ Resolving deltas: 100% (900/900), done.
 No repos with errors
 No repos skipped.
 *** no repos were pulled ***
-Repos downloaded:      Catena-Arduino-Platform arduino-lorawan Catena-mcciadk arduino-lmic Adafruit_FRAM_I2C MCCI-Catena-HS300x
+Repos downloaded:      Catena-Arduino-Platform arduino-lorawan Catena-mcciadk arduino-lmic MCCI_FRAM_I2C MCCI-Catena-HS300x
 ```
 
 It has a number of advanced options; use `../git-boot.sh -h` to get help, or look at the source code [here](https://github.com/mcci-catena/Catena-Sketches/blob/master/git-boot.sh).
@@ -137,7 +137,7 @@ This sketch depends on the following libraries.
 *  https://github.com/mcci-catena/arduino-lorawan
 *  https://github.com/mcci-catena/Catena-mcciadk
 *  https://github.com/mcci-catena/arduino-lmic
-*  https://github.com/mcci-catena/Adafruit_FRAM_I2C
+*  https://github.com/mcci-catena/MCCI_FRAM_I2C
 *  https://github.com/mcci-catena/MCCI-Catena-HS300x
 
 ### Build and Download

--- a/catena4617_simple/git-repos.dat
+++ b/catena4617_simple/git-repos.dat
@@ -5,5 +5,5 @@ github.com	mcci-catena/Catena-Arduino-Platform.git
 github.com	mcci-catena/arduino-lorawan.git
 github.com	mcci-catena/Catena-mcciadk.git
 github.com	mcci-catena/arduino-lmic.git
-github.com	mcci-catena/Adafruit_FRAM_I2C.git
+github.com	mcci-catena/MCCI_FRAM_I2C.git
 github.com	mcci-catena/MCCI-Catena-HS300x.git

--- a/catena4618_simple/README.md
+++ b/catena4618_simple/README.md
@@ -122,7 +122,7 @@ Resolving deltas: 100% (900/900), done.
 No repos with errors
 No repos skipped.
 *** no repos were pulled ***
-Repos downloaded:      Catena-Arduino-Platform arduino-lorawan Catena-mcciadk arduino-lmic Adafruit_FRAM_I2C MCCI-Catena-HS300x
+Repos downloaded:      Catena-Arduino-Platform arduino-lorawan Catena-mcciadk arduino-lmic MCCI_FRAM_I2C MCCI-Catena-HS300x
 ```
 
 It has a number of advanced options; use `../git-boot.sh -h` to get help, or look at the source code [here](https://github.com/mcci-catena/Catena-Sketches/blob/master/git-boot.sh).
@@ -137,7 +137,7 @@ This sketch depends on the following libraries.
 *  https://github.com/mcci-catena/arduino-lorawan
 *  https://github.com/mcci-catena/Catena-mcciadk
 *  https://github.com/mcci-catena/arduino-lmic
-*  https://github.com/mcci-catena/Adafruit_FRAM_I2C
+*  https://github.com/mcci-catena/MCCI_FRAM_I2C
 *  https://github.com/mcci-catena/MCCI-Catena-HS300x
 
 ### Build and Download

--- a/catena4618_simple/git-repos.dat
+++ b/catena4618_simple/git-repos.dat
@@ -5,5 +5,5 @@ github.com	mcci-catena/Catena-Arduino-Platform.git
 github.com	mcci-catena/arduino-lorawan.git
 github.com	mcci-catena/Catena-mcciadk.git
 github.com	mcci-catena/arduino-lmic.git
-github.com	mcci-catena/Adafruit_FRAM_I2C.git
+github.com	mcci-catena/MCCI_FRAM_I2C.git
 github.com	mcci-catena/MCCI-Catena-SHT3x.git

--- a/catena461x_hwtest/README.md
+++ b/catena461x_hwtest/README.md
@@ -109,7 +109,7 @@ Resolving deltas: 100% (900/900), done.
 No repos with errors
 No repos skipped.
 *** no repos were pulled ***
-Repos downloaded:      Catena-Arduino-Platform arduino-lorawan Catena-mcciadk arduino-lmic Adafruit_FRAM_I2C MCCI-Catena-HS300x MCCI-Catena-HS7000x Adafruit_BME280_Library Adafruit_Sensor arduinounit
+Repos downloaded:      Catena-Arduino-Platform arduino-lorawan Catena-mcciadk arduino-lmic MCCI_FRAM_I2C MCCI-Catena-HS300x MCCI-Catena-HS7000x Adafruit_BME280_Library Adafruit_Sensor arduinounit
 ```
 
 It has a number of advanced options; use `../git-boot.sh -h` to get help, or look at the source code [here](https://github.com/mcci-catena/Catena-Sketches/blob/master/git-boot.sh).
@@ -124,7 +124,7 @@ This sketch depends on the following libraries.
 *  https://github.com/mcci-catena/arduino-lorawan
 *  https://github.com/mcci-catena/Catena-mcciadk
 *  https://github.com/mcci-catena/arduino-lmic
-*  https://github.com/mcci-catena/Adafruit_FRAM_I2C
+*  https://github.com/mcci-catena/MCCI_FRAM_I2C
 *  https://github.com/mcci-catena/MCCI-Catena-HS300x
 *  https://github.com/mcci-catena/MCCI-Catena-SHT3x
 *  https://github.com/mcci-catena/MCCI-Catena-HS300x

--- a/catena461x_hwtest/git-repos.dat
+++ b/catena461x_hwtest/git-repos.dat
@@ -5,7 +5,7 @@ github.com	mcci-catena/Catena-Arduino-Platform.git
 github.com	mcci-catena/arduino-lorawan.git
 github.com	mcci-catena/Catena-mcciadk.git
 github.com	mcci-catena/arduino-lmic.git
-github.com	mcci-catena/Adafruit_FRAM_I2C.git
+github.com	mcci-catena/MCCI_FRAM_I2C.git
 github.com	mcci-catena/MCCI-Catena-SHT3x.git
 github.com	mcci-catena/MCCI-Catena-HS300x.git
 github.com	mcci-catena/Adafruit_BME280_Library.git

--- a/catena461x_test01/README.md
+++ b/catena461x_test01/README.md
@@ -3,20 +3,20 @@
 
 - [Introduction](#introduction)
 - [Getting Started](#getting-started)
-	- [Clone this repository into a suitable directory on your system](#clone-this-repository-into-a-suitable-directory-on-your-system)
-	- [Install the MCCI STM32 board support library](#install-the-mcci-stm32-board-support-library)
-	- [Select your desired band](#select-your-desired-band)
-	- [Installing the required libraries](#installing-the-required-libraries)
-		- [List of required libraries](#list-of-required-libraries)
-	- [Build and Download](#build-and-download)
-	- [Load the sketch into the Catena](#load-the-sketch-into-the-catena)
-- [Provision your Catena 4612/4610](#provision-your-catena-4612/4610)
+    - [Clone this repository into a suitable directory on your system](#clone-this-repository-into-a-suitable-directory-on-your-system)
+    - [Install the MCCI STM32 board support library](#install-the-mcci-stm32-board-support-library)
+    - [Select your desired band](#select-your-desired-band)
+    - [Installing the required libraries](#installing-the-required-libraries)
+        - [List of required libraries](#list-of-required-libraries)
+    - [Build and Download](#build-and-download)
+    - [Load the sketch into the Catena](#load-the-sketch-into-the-catena)
+- [Provision your Catena 4612/4610](#provision-your-catena-46124610)
 - [Notes](#notes)
-	- [Setting up DFU on a Linux or Windows PC](#setting-up-dfu-on-a-linux-or-windows-pc)
-	- [Data Format](#data-format)
-	- [Unplugging the USB Cable while running on batteries](#unplugging-the-usb-cable-while-running-on-batteries)
-	- [Deep sleep and USB](#deep-sleep-and-usb)
-	- [gitboot.sh and the other sketches](#gitbootsh-and-the-other-sketches)
+    - [Setting up DFU on a Linux or Windows PC](#setting-up-dfu-on-a-linux-or-windows-pc)
+    - [Data Format](#data-format)
+    - [Unplugging the USB Cable while running on batteries](#unplugging-the-usb-cable-while-running-on-batteries)
+    - [Deep sleep and USB](#deep-sleep-and-usb)
+    - [gitboot.sh and the other sketches](#gitbootsh-and-the-other-sketches)
 
 <!-- /TOC -->
 ## Introduction
@@ -133,7 +133,7 @@ Resolving deltas: 100% (900/900), done.
 
 New repos cloned:
 Adafruit_BME280_Library                 Catena-mcciadk
-Adafruit_FRAM_I2C                       OneWire
+MCCI_FRAM_I2C                           OneWire
 Arduino-Temperature-Control-Library     arduino-lmic
 Catena-Arduino-Platform                 arduino-lorawan
 SHT1x
@@ -151,7 +151,7 @@ This sketch depends on the following libraries.
 *  https://github.com/mcci-catena/arduino-lorawan
 *  https://github.com/mcci-catena/Catena-mcciadk
 *  https://github.com/mcci-catena/arduino-lmic
-*  https://github.com/mcci-catena/Adafruit_FRAM_I2C
+*  https://github.com/mcci-catena/MCCI_FRAM_I2C
 *  https://github.com/mcci-catena/Adafruit_BME280_Library
 *  https://github.com/mcci-catena/Arduino-Temperature-Control-Library
 *  https://github.com/mcci-catena/OneWire

--- a/catena461x_test01/git-repos.dat
+++ b/catena461x_test01/git-repos.dat
@@ -5,7 +5,7 @@ github.com	mcci-catena/Catena-Arduino-Platform.git
 github.com	mcci-catena/arduino-lorawan.git
 github.com	mcci-catena/Catena-mcciadk.git
 github.com	mcci-catena/arduino-lmic.git
-github.com	mcci-catena/Adafruit_FRAM_I2C.git
+github.com	mcci-catena/MCCI_FRAM_I2C.git
 github.com	mcci-catena/Adafruit_BME280_Library.git
 github.com	mcci-catena/Arduino-Temperature-Control-Library.git
 github.com	mcci-catena/OneWire.git

--- a/catena4801_simple/README.md
+++ b/catena4801_simple/README.md
@@ -116,7 +116,7 @@ Resolving deltas: 100% (900/900), done.
 No repos with errors
 No repos skipped.
 *** no repos were pulled ***
-Repos downloaded:      Catena-Arduino-Platform arduino-lorawan Catena-mcciadk arduino-lmic Adafruit_FRAM_I2C Modbus-for-Arduino
+Repos downloaded:      Catena-Arduino-Platform arduino-lorawan Catena-mcciadk arduino-lmic MCCI_FRAM_I2C Modbus-for-Arduino
 ```
 
 It has a number of advanced options; use `../git-boot.sh -h` to get help, or look at the source code [here](https://github.com/mcci-catena/Catena-Sketches/blob/master/git-boot.sh).
@@ -131,7 +131,7 @@ This sketch depends on the following libraries.
 *  https://github.com/mcci-catena/arduino-lorawan
 *  https://github.com/mcci-catena/Catena-mcciadk
 *  https://github.com/mcci-catena/arduino-lmic
-*  https://github.com/mcci-catena/Adafruit_FRAM_I2C
+*  https://github.com/mcci-catena/MCCI_FRAM_I2C
 *  https://github.com/mcci-catena/Modbus-for-Arduino
 
 ### Build and Download

--- a/catena4801_simple/git-repos.dat
+++ b/catena4801_simple/git-repos.dat
@@ -1,7 +1,7 @@
 #
 # list of git repositories to be fetched to Arduino libraries directory.
 #
-github.com	mcci-catena/Adafruit_FRAM_I2C.git
+github.com	mcci-catena/MCCI_FRAM_I2C.git
 github.com	mcci-catena/Catena-Arduino-Platform.git
 github.com	mcci-catena/arduino-lorawan.git
 github.com	mcci-catena/Catena-mcciadk.git


### PR DESCRIPTION
With the rename of MCCI's Adafruit_FRAM_I2C library, we need to go through all the live code and update it. This PR takes care of Catena-Sketches.