### PR TITLE
Fix #114: Switch Si1133 light measurment to forced mode

### DIFF
--- a/catena461x_hwtest/catena461x_hwtest.ino
+++ b/catena461x_hwtest/catena461x_hwtest.ino
@@ -382,7 +382,6 @@ test(2_platform_30_init_lux)
 		gSi1133.configure(0, CATENA_SI1133_MODE_SmallIR);
 		gSi1133.configure(1, CATENA_SI1133_MODE_White);
 		gSi1133.configure(2, CATENA_SI1133_MODE_UV);
-		gSi1133.start();
 		}
 	else
 		{
@@ -417,8 +416,16 @@ testing(3_platform_50_lux)
 		{
 		lasttime = now;
 
+		gSi1133.start(true);
+		delay(300);
+		
 		/* Get a new sensor event */
 		uint16_t data[3];
+		
+		while (! gSi1133.isOneTimeReady())
+			{
+			yield();
+			}
 
 		gSi1133.readMultiChannelData(data, 3);
 		assertLess(data[1], 0xFFFF / 1.2, "Oops: light value pegged: " << data[1]);

--- a/catena461x_test01/catena461x_test01.ino
+++ b/catena461x_test01/catena461x_test01.ino
@@ -288,7 +288,6 @@ void setup(void)
 			gSi1133.configure(0, CATENA_SI1133_MODE_SmallIR);
 			gSi1133.configure(1, CATENA_SI1133_MODE_White);
 			gSi1133.configure(2, CATENA_SI1133_MODE_UV);
-			gSi1133.start();
 			}
 		else
 			{
@@ -488,9 +487,12 @@ static uint16_t dNdT_getFrac(
 	}
 
 void startSendingUplink(void)
-{
+	{
 	TxBuffer_t b;
 	LedPattern savedLed = gLed.Set(LedPattern::Measuring);
+
+	if (fLux)
+		gSi1133.start(true);
 
 	b.begin();
 	FlagsSensor2 flag;
@@ -542,6 +544,11 @@ void startSendingUplink(void)
 		{
 		/* Get a new sensor event */
 		uint16_t data[3];
+
+		while (! gSi1133.isOneTimeReady())
+			{
+			yield();
+			}
 
 		gSi1133.readMultiChannelData(data, 3);
 		gSi1133.stop();
@@ -723,7 +730,6 @@ static void sleepDoneCb(
 	)
 	{
 	gLed.Set(LedPattern::WarmingUp);
-	gSi1133.start();
 
 	os_setTimedCallback(
 		&sensorJob,


### PR DESCRIPTION
Updated catena461x_hwtest and catena461x_test01 with Si1133 in forced mode.