### PR TITLE
Fix #116: updated .dat file in catena4612_simple for the repo Adafruit_Sensor

### DIFF
--- a/catena4612_simple/git-repos.dat
+++ b/catena4612_simple/git-repos.dat
@@ -1,9 +1,10 @@
 #
 # list of git repositories to be fetched to Arduino libraries directory.
 #
-github.com	mcci-catena/Catena-Arduino-Platform.git
-github.com	mcci-catena/arduino-lorawan.git
-github.com	mcci-catena/Catena-mcciadk.git
-github.com	mcci-catena/arduino-lmic.git
-github.com	mcci-catena/MCCI_FRAM_I2C.git
-github.com	mcci-catena/Adafruit_BME280_Library.git
+github.com      mcci-catena/Catena-Arduino-Platform.git
+github.com      mcci-catena/arduino-lorawan.git
+github.com      mcci-catena/Catena-mcciadk.git
+github.com      mcci-catena/arduino-lmic.git
+github.com      mcci-catena/MCCI_FRAM_I2C.git
+github.com      mcci-catena/Adafruit_BME280_Library.git
+github.com      mcci-catena/Adafruit_Sensor.git


### PR DESCRIPTION
Updated the `git-repos.dat` for sketch `catena4612_simple` with the repo `Adafruit_Sensor`. Tested in parallel, able to build without any errors.
Reference to issue #116 