### PR TITLE
Fix #118: updated ".dat" files with repo Adafruit_Sensor.git

### DIFF
--- a/catena4551_test01/git-repos.dat
+++ b/catena4551_test01/git-repos.dat
@@ -1,12 +1,13 @@
 #
 # list of git repositories to be fetched to Arduino libraries directory.
 #
-github.com	mcci-catena/Catena-Arduino-Platform.git
-github.com	mcci-catena/arduino-lorawan.git
-github.com	mcci-catena/Catena-mcciadk.git
-github.com	mcci-catena/arduino-lmic.git
-github.com	mcci-catena/MCCI_FRAM_I2C.git
-github.com	mcci-catena/Adafruit_BME280_Library.git
-github.com	mcci-catena/Arduino-Temperature-Control-Library.git
-github.com	mcci-catena/OneWire.git
-github.com	mcci-catena/SHT1x.git
+github.com      mcci-catena/Catena-Arduino-Platform.git
+github.com      mcci-catena/arduino-lorawan.git
+github.com      mcci-catena/Catena-mcciadk.git
+github.com      mcci-catena/arduino-lmic.git
+github.com      mcci-catena/MCCI_FRAM_I2C.git
+github.com      mcci-catena/Adafruit_BME280_Library.git
+github.com      mcci-catena/Arduino-Temperature-Control-Library.git
+github.com      mcci-catena/OneWire.git
+github.com      mcci-catena/SHT1x.git
+github.com      mcci-catena/Adafruit_Sensor.git

--- a/catena4551_test02/git-repos.dat
+++ b/catena4551_test02/git-repos.dat
@@ -1,13 +1,14 @@
 #
 # list of git repositories to be fetched to Arduino libraries directory.
 #
-github.com	mcci-catena/Catena-Arduino-Platform.git
-github.com	mcci-catena/arduino-lorawan.git
-github.com	mcci-catena/Catena-mcciadk.git
-github.com	mcci-catena/arduino-lmic.git
-github.com	mcci-catena/MCCI_FRAM_I2C.git
-github.com	mcci-catena/Adafruit_BME280_Library.git
-github.com	mcci-catena/Arduino-Temperature-Control-Library.git
-github.com	mcci-catena/BH1750.git
-github.com	mcci-catena/OneWire.git
-github.com	mcci-catena/SHT1x.git
+github.com      mcci-catena/Catena-Arduino-Platform.git
+github.com      mcci-catena/arduino-lorawan.git
+github.com      mcci-catena/Catena-mcciadk.git
+github.com      mcci-catena/arduino-lmic.git
+github.com      mcci-catena/MCCI_FRAM_I2C.git
+github.com      mcci-catena/Adafruit_BME280_Library.git
+github.com      mcci-catena/Arduino-Temperature-Control-Library.git
+github.com      mcci-catena/BH1750.git
+github.com      mcci-catena/OneWire.git
+github.com      mcci-catena/SHT1x.git
+github.com      mcci-catena/Adafruit_Sensor.git

--- a/catena461x_test01/git-repos.dat
+++ b/catena461x_test01/git-repos.dat
@@ -1,12 +1,13 @@
 #
 # list of git repositories to be fetched to Arduino libraries directory.
 #
-github.com	mcci-catena/Catena-Arduino-Platform.git
-github.com	mcci-catena/arduino-lorawan.git
-github.com	mcci-catena/Catena-mcciadk.git
-github.com	mcci-catena/arduino-lmic.git
-github.com	mcci-catena/MCCI_FRAM_I2C.git
-github.com	mcci-catena/Adafruit_BME280_Library.git
-github.com	mcci-catena/Arduino-Temperature-Control-Library.git
-github.com	mcci-catena/OneWire.git
-github.com	mcci-catena/SHT1x.git
+github.com      mcci-catena/Catena-Arduino-Platform.git
+github.com      mcci-catena/arduino-lorawan.git
+github.com      mcci-catena/Catena-mcciadk.git
+github.com      mcci-catena/arduino-lmic.git
+github.com      mcci-catena/MCCI_FRAM_I2C.git
+github.com      mcci-catena/Adafruit_BME280_Library.git
+github.com      mcci-catena/Arduino-Temperature-Control-Library.git
+github.com      mcci-catena/OneWire.git
+github.com      mcci-catena/SHT1x.git
+github.com      mcci-catena/Adafruit_Sensor.git


### PR DESCRIPTION
Updated the `git-repos.dat` for sketches `catena4551_test01`, `catena4551_test02`, `catena461x_test01` with the repo `Adafruit_Sensor`. Tested in parallel, able to build the sketches without any errors. Similar to Pull-request #117  